### PR TITLE
feat(auth): implement refresh token flow with JWT_SECRET-based verifi…

### DIFF
--- a/src/controllers/access.controller.js
+++ b/src/controllers/access.controller.js
@@ -3,7 +3,7 @@
 
 import { CREATED, OK } from "../core/success.respose.js"
 import AccessService from "../services/access.service.js"
-import KeyTokenService from "../services/keyToken.service.js"
+
 
 class AccessController {
     logIn = async (req, res, next) => {
@@ -30,6 +30,15 @@ class AccessController {
 
         return new CREATED({
             message: 'Account Registered Successfully!',
+            metadata: result
+        }).send(res)
+    }
+
+    refreshToken = async (req, res, next) => {
+        const result = await AccessService.handleRefreshToken(req.body.refreshToken)
+
+        return new CREATED({
+            message: 'Access Token And Refresh Token Created Successfully!',
             metadata: result
         }).send(res)
     }


### PR DESCRIPTION
…cation

- Added handleRefreshToken method in AccessService to verify and decode refresh tokens using JWT_SECRET_REFRESH
- Replaced per-user key lookup with stateless JWT handling
- Used userId from token payload for secure DB lookup
- Fixed missing  in async call to ShopModel.findByEmail
- Added refreshToken controller method to handle token renewal
- Updated /refresh-token logic to return new access and refresh tokens
- Cleaned up legacy KeyTokenService reference (no longer used)
- Improved error handling for missing or invalid refresh tokens

This refactor completes the transition to fully stateless, symmetric JWT auth with best practices for token lifecycle management.